### PR TITLE
Force use of mdbook 0.2.1 as 0.2.2 is broken for now

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -6,6 +6,8 @@ main() {
                     | grep -E '^v0.2.[0-9]+$' \
                     | sort --version-sort \
                     | tail -n1)
+    # Temporarily use older version until packages are available for 0.2.2 (or newer)
+    local tag="v0.2.1"
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- --git rust-lang-nursery/mdbook --tag $tag
 


### PR DESCRIPTION
See https://github.com/rust-embedded/book/pull/58