### PR TITLE
Fix image links in Discovery book

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -49,7 +49,8 @@ main() {
     rm -rf $tmpdir
 
     # check links
-    linkchecker doc
+    # mdbook doesn't handle relative links correctly in print.html so skip it.
+    linkchecker --ignore-url "discovery/print.html" doc
 }
 
 main


### PR DESCRIPTION
The links have already been fixed in the discovery repository and this PR just updates the CI scripts in the bookshelf repo to ignore the print.html link errors so that the bookshelf version will have the fixes too.

More information about the reason for the CI script change follows:

rust-lang-nursery/mdBook#789 causes
mdbook to generate print.html content with relative URLs that
are still relative to the individual HTML files and doesn't
correct for the fact that print.html isn't in the same folder.

This commit will verify that the relative URLs are correct in all
of the HTML output except for discovery/print.html  I am assuming
that people would like to see the images again in the Discovery
book website as they click through the various chapters, even if
the printable version is still broken.

I have already made the same change to the CI scripts in the
discovery repository along with various link fixes.

Once this PR is merged, an issue should be created to track the
fact that this change should be reverted once mdbook handles
relative links correctly in its generaton of print.html