### PR TITLE
Ignore all print.html files from linkchecker

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -49,8 +49,8 @@ main() {
     rm -rf $tmpdir
 
     # check links
-    # mdbook doesn't handle relative links correctly in print.html so skip it.
-    linkchecker --ignore-url "discovery/print.html" doc
+    # FIXME(rust-lang-nursery/mdbook#789) remove `--ignore-url` when that bug is fixed
+    linkchecker --ignore-url "print.html" doc
 }
 
 main


### PR DESCRIPTION
Previously I was just ignoring the print.html for the discovery book
since it was the only bookshelf documentation that was failing link
checks in print.html but the embedded Rust book is failing too now
after
 https://github.com/rust-embedded/book/commit/cf66108f200f6b6eb75d47fdaf72f05684060a06
and
 https://github.com/rust-embedded/book/commit/e310669d0e8ecd0309f22321378b84857db15f22